### PR TITLE
Pass batch size limit from caller to partitioning methods

### DIFF
--- a/integration_tests/src/main/python/col_size_exceeding_cudf_limit_test.py
+++ b/integration_tests/src/main/python/col_size_exceeding_cudf_limit_test.py
@@ -55,7 +55,7 @@ def extract_partition_cols(gen_list):
 @inject_oom
 @pytest.mark.parametrize("key", gen_list_dict.keys())
 def test_col_size_exceeding_cudf_limit(spark_tmp_path, key):
-    conf = {'spark.rapids.cudfColumnSizeLimit': 1000}
+    conf = {'spark.rapids.sql.batchSizeBytes': 1000}
     gen_list = gen_list_dict[key]
     partition_cols = extract_partition_cols(gen_list)
     gen = StructGen(gen_list, nullable=False)

--- a/integration_tests/src/main/python/col_size_exceeding_cudf_limit_test.py
+++ b/integration_tests/src/main/python/col_size_exceeding_cudf_limit_test.py
@@ -73,7 +73,7 @@ def extract_partition_cols(gen_list):
 @inject_oom
 @pytest.mark.parametrize("key", gen_list_dict.keys())
 def test_col_size_exceeding_cudf_limit(spark_tmp_path, key):
-    conf = {'spark.rapids.sql.batchSizeBytes': 1000}
+    conf = {'spark.rapids.sql.columnSizeBytes': 1000}
     gen_list = gen_list_dict[key]
     partition_cols = extract_partition_cols(gen_list)
     gen = StructGen(gen_list, nullable=False)

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuMultiFileBatchReader.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuMultiFileBatchReader.java
@@ -65,6 +65,7 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
   private final int maxBatchSizeRows;
   private final long maxBatchSizeBytes;
   private final long targetBatchSizeBytes;
+  private final long maxGpuColumnSizeBytes;
 
   private final boolean useChunkedReader;
   private final scala.Option<String> parquetDebugDumpPrefix;
@@ -84,7 +85,7 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
 
   GpuMultiFileBatchReader(CombinedScanTask task, Table table, Schema expectedSchema,
       boolean caseSensitive, Configuration conf, int maxBatchSizeRows, long maxBatchSizeBytes,
-      long targetBatchSizeBytes,
+      long targetBatchSizeBytes, long maxGpuColumnSizeBytes,
       boolean useChunkedReader,
       scala.Option<String> parquetDebugDumpPrefix, boolean parquetDebugDumpAlways,
       int numThreads, int maxNumFileProcessed,
@@ -98,6 +99,7 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
     this.maxBatchSizeRows = maxBatchSizeRows;
     this.maxBatchSizeBytes = maxBatchSizeBytes;
     this.targetBatchSizeBytes = targetBatchSizeBytes;
+    this.maxGpuColumnSizeBytes = maxGpuColumnSizeBytes;
     this.useChunkedReader = useChunkedReader;
     this.parquetDebugDumpPrefix = parquetDebugDumpPrefix;
     this.parquetDebugDumpAlways = parquetDebugDumpAlways;
@@ -333,8 +335,8 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
         StructType partitionSchema) {
       return new MultiFileCloudParquetPartitionReader(conf, pFiles,
           this::filterParquetBlocks, caseSensitive, parquetDebugDumpPrefix, parquetDebugDumpAlways,
-          maxBatchSizeRows, maxBatchSizeBytes, targetBatchSizeBytes, useChunkedReader,
-          metrics, partitionSchema,
+          maxBatchSizeRows, maxBatchSizeBytes, targetBatchSizeBytes, maxGpuColumnSizeBytes,
+          useChunkedReader, metrics, partitionSchema,
           numThreads, maxNumFileProcessed,
           false, // ignoreMissingFiles
           false, // ignoreCorruptFiles
@@ -407,8 +409,8 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
       return new MultiFileParquetPartitionReader(conf, pFiles,
           JavaConverters.asScalaBuffer(clippedBlocks).toSeq(),
           caseSensitive, parquetDebugDumpPrefix, parquetDebugDumpAlways, useChunkedReader,
-          maxBatchSizeRows, maxBatchSizeBytes, targetBatchSizeBytes, metrics, partitionSchema,
-          numThreads,
+          maxBatchSizeRows, maxBatchSizeBytes, targetBatchSizeBytes, maxGpuColumnSizeBytes,
+          metrics, partitionSchema, numThreads,
           false, // ignoreMissingFiles
           false, // ignoreCorruptFiles
           false // useFieldId

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuSparkScan.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuSparkScan.java
@@ -282,7 +282,7 @@ abstract class GpuSparkScan extends GpuScanWrapper
                          boolean queryUsesInputFile) {
       super(task.task, task.table(), task.expectedSchema(), task.isCaseSensitive(),
           task.getConfiguration(), task.getMaxBatchSizeRows(), task.getMaxBatchSizeBytes(),
-          task.getTargetBatchSizeBytes(), task.useChunkedReader(),
+          task.getTargetBatchSizeBytes(), task.getMaxBatchSizeBytes(), task.useChunkedReader(),
           task.getParquetDebugDumpPrefix(), task.getParquetDebugDumpAlways(),
           task.getNumThreads(), task.getMaxNumFileProcessed(),
           useMultiThread, ff, metrics, queryUsesInputFile);
@@ -309,6 +309,7 @@ abstract class GpuSparkScan extends GpuScanWrapper
     private final long maxBatchSizeBytes;
 
     private final long targetBatchSizeBytes;
+    private final long maxGpuColumnSizeBytes;
     private final scala.Option<String> parquetDebugDumpPrefix;
     private final boolean parquetDebugDumpAlways;
     private final int numThreads;
@@ -334,6 +335,7 @@ abstract class GpuSparkScan extends GpuScanWrapper
       this.maxBatchSizeRows = rapidsConf.maxReadBatchSizeRows();
       this.maxBatchSizeBytes = rapidsConf.maxReadBatchSizeBytes();
       this.targetBatchSizeBytes = rapidsConf.gpuTargetBatchSizeBytes();
+      this.maxGpuColumnSizeBytes = rapidsConf.maxGpuColumnSizeBytes();
       this.parquetDebugDumpPrefix = rapidsConf.parquetDebugDumpPrefix();
       this.parquetDebugDumpAlways = rapidsConf.parquetDebugDumpAlways();
       this.numThreads = rapidsConf.multiThreadReadNumThreads();
@@ -372,6 +374,10 @@ abstract class GpuSparkScan extends GpuScanWrapper
 
     public long getTargetBatchSizeBytes() {
       return targetBatchSizeBytes;
+    }
+
+    public long getMaxGpuColumnSizeBytes() {
+      return maxGpuColumnSizeBytes;
     }
 
     public scala.Option<String> getParquetDebugDumpPrefix() {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/BatchWithPartitionData.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/BatchWithPartitionData.scala
@@ -25,7 +25,6 @@ import com.nvidia.spark.rapids.RmmRapidsRetryIterator.withRetry
 import com.nvidia.spark.rapids.jni.SplitAndRetryOOM
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -133,31 +132,34 @@ class BatchWithPartitionDataIterator(batchesWithPartitionData: Seq[BatchWithPart
 object BatchWithPartitionDataUtils {
   /**
    * Splits partition data (values and row counts) into smaller batches, ensuring that
-   * size of batch is less than cuDF size limit. Then, it utilizes these smaller
+   * size of batch is less than target batch size. Then, it utilizes these smaller
    * partitioned batches to split the input batch and merges them to generate
    * an Iterator of split ColumnarBatches.
    *
    * Using an Iterator ensures that the actual merging does not happen until
    * the batch is required, thus avoiding GPU memory wastage.
    *
-   * @param batch           Input batch, will be closed after the call returns
-   * @param partitionValues Partition values collected from the batch
-   * @param partitionRows   Row numbers collected from the batch, and it should have
-   *                        the same size with "partitionValues"
-   * @param partitionSchema Partition schema
+   * @param batch                 Input batch, will be closed after the call returns
+   * @param partitionValues       Partition values collected from the batch
+   * @param partitionRows         Row numbers collected from the batch, and it should have
+   *                              the same size with "partitionValues"
+   * @param partitionSchema       Partition schema
+   * @param targetBatchSizeBytes  Target size of batch in bytes
    * @return a new columnar batch iterator with partition values
    */
   def addPartitionValuesToBatch(
       batch: ColumnarBatch,
       partitionRows: Array[Long],
       partitionValues: Array[InternalRow],
-      partitionSchema: StructType): GpuColumnarBatchIterator = {
+      partitionSchema: StructType,
+      targetBatchSizeBytes: Long): GpuColumnarBatchIterator = {
     if (partitionSchema.nonEmpty) {
       withResource(batch) { _ =>
         val partitionRowData = partitionValues.zip(partitionRows).map {
           case (rowValue, rowNum) => PartitionRowData(rowValue, rowNum.toInt)
         }
-        val partitionedGroups = splitPartitionDataIntoGroups(partitionRowData, partitionSchema)
+        val partitionedGroups = splitPartitionDataIntoGroups(partitionRowData, partitionSchema,
+          targetBatchSizeBytes)
         val splitBatches = splitAndCombineBatchWithPartitionData(batch, partitionedGroups,
           partitionSchema)
         new BatchWithPartitionDataIterator(splitBatches)
@@ -168,19 +170,24 @@ object BatchWithPartitionDataUtils {
   }
 
   /**
-   * Adds a single set of partition values to all rows in a ColumnarBatch.
+   * Adds a single set of partition values to all rows in a ColumnarBatch ensuring that
+   * size of batch is less than target batch size.
+   *
    * @return a new columnar batch iterator with partition values
+   * @see [[com.nvidia.spark.rapids.BatchWithPartitionDataUtils.addPartitionValuesToBatch]]
    */
   def addSinglePartitionValueToBatch(
       batch: ColumnarBatch,
       partitionValues: InternalRow,
-      partitionSchema: StructType): GpuColumnarBatchIterator = {
-    addPartitionValuesToBatch(batch, Array(batch.numRows), Array(partitionValues), partitionSchema)
+      partitionSchema: StructType,
+      targetBatchSizeBytes: Long): GpuColumnarBatchIterator = {
+    addPartitionValuesToBatch(batch, Array(batch.numRows), Array(partitionValues), partitionSchema,
+      targetBatchSizeBytes)
   }
 
   /**
    * Splits partitions into smaller batches, ensuring that the batch size
-   * for each column does not exceed the maximum column size limit.
+   * for each column does not exceed the maximum batch size limit.
    *
    * Data structures:
    *  - sizeOfBatch:   Array that stores the size of batches for each column.
@@ -221,8 +228,8 @@ object BatchWithPartitionDataUtils {
    */
   private def splitPartitionDataIntoGroups(
       partitionRowData: Array[PartitionRowData],
-      partSchema: StructType): Array[Array[PartitionRowData]] = {
-    val maxColumnSize = getMaxColumnSize
+      partSchema: StructType,
+      targetBatchSizeBytes: Long): Array[Array[PartitionRowData]] = {
     val resultBatches = ArrayBuffer[Array[PartitionRowData]]()
     val currentBatch = ArrayBuffer[PartitionRowData]()
     val sizeOfBatch = Array.fill(partSchema.length)(0L)
@@ -237,7 +244,8 @@ object BatchWithPartitionDataUtils {
         rowsInPartition = currentPartition.rowNum
       }
       // Calculate the maximum number of rows that can fit in current batch.
-      val maxRows = calculateMaxRows(currentPartition, partSchema, sizeOfBatch, maxColumnSize)
+      val maxRows = calculateMaxRows(currentPartition, partSchema, sizeOfBatch,
+        targetBatchSizeBytes)
       // Splitting occurs if for any column, maximum rows we can fit is less than rows in partition.
       splitOccurred = maxRows < rowsInPartition
       if (splitOccurred) {
@@ -264,13 +272,6 @@ object BatchWithPartitionDataUtils {
   }
 
   /**
-   * Retrieves the maximum size for cuDF column vector from the configuration.
-   */
-  private def getMaxColumnSize: Long = {
-    new RapidsConf(SQLConf.get).cudfColumnSizeLimit
-  }
-
-  /**
    * Calculates the partition size for each column as 'size of single value * number of rows'
    */
   private def calculatePartitionSizes(partitionRowData: PartitionRowData,
@@ -289,12 +290,12 @@ object BatchWithPartitionDataUtils {
    * Calculate the maximum number of rows that can fit into a batch without exceeding limit.
    */
   private def calculateMaxRows(partitionRowData: PartitionRowData, partSchema: StructType,
-      sizeOfBatch: Array[Long], maxColumnSize: Long): Int = {
+      sizeOfBatch: Array[Long], targetBatchSizeBytes: Long): Int = {
     partSchema.zipWithIndex.map {
       case (field, colIndex) if !partitionRowData.rowValue.isNullAt(colIndex)
         && field.dataType == StringType =>
         val sizeOfSingleValue = partitionRowData.rowValue.getUTF8String(colIndex).numBytes
-        val availableSpace = maxColumnSize - sizeOfBatch(colIndex)
+        val availableSpace = targetBatchSizeBytes - sizeOfBatch(colIndex)
         // Calculated max row numbers that can fit.
         val maxRows = (availableSpace / sizeOfSingleValue).toInt
         maxRows

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarPartitionReaderWithPartitionValues.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarPartitionReaderWithPartitionValues.scala
@@ -32,7 +32,7 @@ class ColumnarPartitionReaderWithPartitionValues(
     fileReader: PartitionReader[ColumnarBatch],
     partitionValues: InternalRow,
     partitionSchema: StructType,
-    targetBatchSizeBytes: Long) extends PartitionReader[ColumnarBatch] {
+    maxGpuColumnSizeBytes: Long) extends PartitionReader[ColumnarBatch] {
   override def next(): Boolean = fileReader.next()
   private var outputIter: Iterator[ColumnarBatch] = Iterator.empty
 
@@ -45,7 +45,7 @@ class ColumnarPartitionReaderWithPartitionValues(
     } else {
       val fileBatch: ColumnarBatch = fileReader.get()
       outputIter = BatchWithPartitionDataUtils.addPartitionValuesToBatch(fileBatch,
-        Array(fileBatch.numRows), Array(partitionValues), partitionSchema, targetBatchSizeBytes)
+        Array(fileBatch.numRows), Array(partitionValues), partitionSchema, maxGpuColumnSizeBytes)
       outputIter.next()
     }
   }
@@ -59,8 +59,8 @@ object ColumnarPartitionReaderWithPartitionValues {
   def newReader(partFile: PartitionedFile,
       baseReader: PartitionReader[ColumnarBatch],
       partitionSchema: StructType,
-      targetBatchSizeBytes: Long): PartitionReader[ColumnarBatch] = {
+      maxGpuColumnSizeBytes: Long): PartitionReader[ColumnarBatch] = {
     new ColumnarPartitionReaderWithPartitionValues(baseReader, partFile.partitionValues,
-      partitionSchema, targetBatchSizeBytes)
+      partitionSchema, maxGpuColumnSizeBytes)
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarPartitionReaderWithPartitionValues.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarPartitionReaderWithPartitionValues.scala
@@ -31,7 +31,8 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 class ColumnarPartitionReaderWithPartitionValues(
     fileReader: PartitionReader[ColumnarBatch],
     partitionValues: InternalRow,
-    partitionSchema: StructType) extends PartitionReader[ColumnarBatch] {
+    partitionSchema: StructType,
+    targetBatchSizeBytes: Long) extends PartitionReader[ColumnarBatch] {
   override def next(): Boolean = fileReader.next()
   private var outputIter: Iterator[ColumnarBatch] = Iterator.empty
 
@@ -44,7 +45,7 @@ class ColumnarPartitionReaderWithPartitionValues(
     } else {
       val fileBatch: ColumnarBatch = fileReader.get()
       outputIter = BatchWithPartitionDataUtils.addPartitionValuesToBatch(fileBatch,
-        Array(fileBatch.numRows), Array(partitionValues), partitionSchema)
+        Array(fileBatch.numRows), Array(partitionValues), partitionSchema, targetBatchSizeBytes)
       outputIter.next()
     }
   }
@@ -57,8 +58,9 @@ class ColumnarPartitionReaderWithPartitionValues(
 object ColumnarPartitionReaderWithPartitionValues {
   def newReader(partFile: PartitionedFile,
       baseReader: PartitionReader[ColumnarBatch],
-      partitionSchema: StructType): PartitionReader[ColumnarBatch] = {
+      partitionSchema: StructType,
+      targetBatchSizeBytes: Long): PartitionReader[ColumnarBatch] = {
     new ColumnarPartitionReaderWithPartitionValues(baseReader, partFile.partitionValues,
-      partitionSchema)
+      partitionSchema, targetBatchSizeBytes)
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
@@ -209,7 +209,8 @@ case class GpuCSVScan(
     partitionFilters: Seq[Expression],
     dataFilters: Seq[Expression],
     maxReaderBatchSizeRows: Integer,
-    maxReaderBatchSizeBytes: Long)
+    maxReaderBatchSizeBytes: Long,
+    targetBatchSizeBytes: Long)
   extends TextBasedFileScan(sparkSession, options) with GpuScan {
 
   private lazy val parsedOptions: CSVOptions = new CSVOptions(
@@ -240,7 +241,7 @@ case class GpuCSVScan(
 
     GpuCSVPartitionReaderFactory(sparkSession.sessionState.conf, broadcastedConf,
       dataSchema, readDataSchema, readPartitionSchema, parsedOptions, maxReaderBatchSizeRows,
-      maxReaderBatchSizeBytes, metrics, options.asScala.toMap)
+      maxReaderBatchSizeBytes, targetBatchSizeBytes, metrics, options.asScala.toMap)
   }
 
   // overrides nothing in 330
@@ -254,7 +255,8 @@ case class GpuCSVScan(
     case c: GpuCSVScan =>
       super.equals(c) && dataSchema == c.dataSchema && options == c.options &&
       maxReaderBatchSizeRows == c.maxReaderBatchSizeRows &&
-      maxReaderBatchSizeBytes == c.maxReaderBatchSizeBytes
+      maxReaderBatchSizeBytes == c.maxReaderBatchSizeBytes &&
+        targetBatchSizeBytes == c.targetBatchSizeBytes
     case _ => false
   }
 
@@ -271,6 +273,7 @@ case class GpuCSVPartitionReaderFactory(
     parsedOptions: CSVOptions,
     maxReaderBatchSizeRows: Integer,
     maxReaderBatchSizeBytes: Long,
+    targetBatchSizeBytes: Long,
     metrics: Map[String, GpuMetric],
     @transient params: Map[String, String]) extends ShimFilePartitionReaderFactory(params) {
 
@@ -282,7 +285,8 @@ case class GpuCSVPartitionReaderFactory(
     val conf = broadcastedConf.value.value
     val reader = new PartitionReaderWithBytesRead(new CSVPartitionReader(conf, partFile, dataSchema,
       readDataSchema, parsedOptions, maxReaderBatchSizeRows, maxReaderBatchSizeBytes, metrics))
-    ColumnarPartitionReaderWithPartitionValues.newReader(partFile, reader, partitionSchema)
+    ColumnarPartitionReaderWithPartitionValues.newReader(partFile, reader, partitionSchema,
+      targetBatchSizeBytes)
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
@@ -210,7 +210,7 @@ case class GpuCSVScan(
     dataFilters: Seq[Expression],
     maxReaderBatchSizeRows: Integer,
     maxReaderBatchSizeBytes: Long,
-    targetBatchSizeBytes: Long)
+    maxGpuColumnSizeBytes: Long)
   extends TextBasedFileScan(sparkSession, options) with GpuScan {
 
   private lazy val parsedOptions: CSVOptions = new CSVOptions(
@@ -241,7 +241,7 @@ case class GpuCSVScan(
 
     GpuCSVPartitionReaderFactory(sparkSession.sessionState.conf, broadcastedConf,
       dataSchema, readDataSchema, readPartitionSchema, parsedOptions, maxReaderBatchSizeRows,
-      maxReaderBatchSizeBytes, targetBatchSizeBytes, metrics, options.asScala.toMap)
+      maxReaderBatchSizeBytes, maxGpuColumnSizeBytes, metrics, options.asScala.toMap)
   }
 
   // overrides nothing in 330
@@ -256,7 +256,7 @@ case class GpuCSVScan(
       super.equals(c) && dataSchema == c.dataSchema && options == c.options &&
       maxReaderBatchSizeRows == c.maxReaderBatchSizeRows &&
       maxReaderBatchSizeBytes == c.maxReaderBatchSizeBytes &&
-        targetBatchSizeBytes == c.targetBatchSizeBytes
+        maxGpuColumnSizeBytes == c.maxGpuColumnSizeBytes
     case _ => false
   }
 
@@ -273,7 +273,7 @@ case class GpuCSVPartitionReaderFactory(
     parsedOptions: CSVOptions,
     maxReaderBatchSizeRows: Integer,
     maxReaderBatchSizeBytes: Long,
-    targetBatchSizeBytes: Long,
+    maxGpuColumnSizeBytes: Long,
     metrics: Map[String, GpuMetric],
     @transient params: Map[String, String]) extends ShimFilePartitionReaderFactory(params) {
 
@@ -286,7 +286,7 @@ case class GpuCSVPartitionReaderFactory(
     val reader = new PartitionReaderWithBytesRead(new CSVPartitionReader(conf, partFile, dataSchema,
       readDataSchema, parsedOptions, maxReaderBatchSizeRows, maxReaderBatchSizeBytes, metrics))
     ColumnarPartitionReaderWithPartitionValues.newReader(partFile, reader, partitionSchema,
-      targetBatchSizeBytes)
+      maxGpuColumnSizeBytes)
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchIterator.scala
@@ -97,12 +97,14 @@ class SingleGpuColumnarBatchIterator(private var batch: ColumnarBatch)
  * @param partRowNums row numbers collected from all the batches in the input iterator, it
  *                    should have the same size with "partValues".
  * @param partSchema the partition schema
+ * @param targetBatchSizeBytes target number of bytes for a GPU batch
  */
 class GpuColumnarBatchWithPartitionValuesIterator(
     inputIter: Iterator[ColumnarBatch],
     partValues: Array[InternalRow],
     partRowNums: Array[Long],
-    partSchema: StructType) extends Iterator[ColumnarBatch] {
+    partSchema: StructType,
+    targetBatchSizeBytes: Long) extends Iterator[ColumnarBatch] {
   assert(partValues.length == partRowNums.length)
 
   private var leftValues: Array[InternalRow] = partValues
@@ -123,7 +125,7 @@ class GpuColumnarBatchWithPartitionValuesIterator(
           computeValuesAndRowNumsForBatch(batch.numRows())
         }
         outputIter = BatchWithPartitionDataUtils.addPartitionValuesToBatch(batch, readPartRows,
-          readPartValues, partSchema)
+          readPartValues, partSchema, targetBatchSizeBytes)
         outputIter.next()
       } else {
         batch

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchIterator.scala
@@ -97,14 +97,14 @@ class SingleGpuColumnarBatchIterator(private var batch: ColumnarBatch)
  * @param partRowNums row numbers collected from all the batches in the input iterator, it
  *                    should have the same size with "partValues".
  * @param partSchema the partition schema
- * @param targetBatchSizeBytes target number of bytes for a GPU batch
+ * @param maxGpuColumnSizeBytes maximum number of bytes for a GPU column
  */
 class GpuColumnarBatchWithPartitionValuesIterator(
     inputIter: Iterator[ColumnarBatch],
     partValues: Array[InternalRow],
     partRowNums: Array[Long],
     partSchema: StructType,
-    targetBatchSizeBytes: Long) extends Iterator[ColumnarBatch] {
+    maxGpuColumnSizeBytes: Long) extends Iterator[ColumnarBatch] {
   assert(partValues.length == partRowNums.length)
 
   private var leftValues: Array[InternalRow] = partValues
@@ -125,7 +125,7 @@ class GpuColumnarBatchWithPartitionValuesIterator(
           computeValuesAndRowNumsForBatch(batch.numRows())
         }
         outputIter = BatchWithPartitionDataUtils.addPartitionValuesToBatch(batch, readPartRows,
-          readPartValues, partSchema, targetBatchSizeBytes)
+          readPartValues, partSchema, maxGpuColumnSizeBytes)
         outputIter.next()
       } else {
         batch

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -215,6 +215,7 @@ abstract class MultiFilePartitionReaderFactoryBase(
   protected val maxReadBatchSizeRows: Int = rapidsConf.maxReadBatchSizeRows
   protected val maxReadBatchSizeBytes: Long = rapidsConf.maxReadBatchSizeBytes
   protected val targetBatchSizeBytes: Long = rapidsConf.gpuTargetBatchSizeBytes
+  protected val maxGpuColumnSizeBytes: Long = rapidsConf.maxGpuColumnSizeBytes
   private val allCloudSchemes = rapidsConf.getCloudSchemes.toSet
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
@@ -822,7 +823,7 @@ class BatchContext(
  * @param partitionSchema       schema of partitions
  * @param maxReadBatchSizeRows  soft limit on the maximum number of rows the reader reads per batch
  * @param maxReadBatchSizeBytes soft limit on the maximum number of bytes the reader reads per batch
- * @param targetBatchSizeBytes target number of bytes for a GPU batch
+ * @param maxGpuColumnSizeBytes maximum number of bytes for a GPU column
  * @param numThreads            the size of the threadpool
  * @param execMetrics           metrics
  */
@@ -832,7 +833,7 @@ abstract class MultiFileCoalescingPartitionReaderBase(
     partitionSchema: StructType,
     maxReadBatchSizeRows: Integer,
     maxReadBatchSizeBytes: Long,
-    targetBatchSizeBytes: Long,
+    maxGpuColumnSizeBytes: Long,
     numThreads: Int,
     execMetrics: Map[String, GpuMetric]) extends FilePartitionReaderBase(conf, execMetrics)
     with MultiFileReaderFunctions {
@@ -1078,7 +1079,7 @@ abstract class MultiFileCoalescingPartitionReaderBase(
       }
       new GpuColumnarBatchWithPartitionValuesIterator(batchIter, currentChunkMeta.allPartValues,
         currentChunkMeta.rowsPerPartition, partitionSchema,
-        targetBatchSizeBytes).map { withParts =>
+        maxGpuColumnSizeBytes).map { withParts =>
         withResource(withParts) { _ =>
           finalizeOutputBatch(withParts, currentChunkMeta.extraInfo)
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -562,9 +562,9 @@ case class GpuOrcMultiFilePartitionReaderFactory(
       PartitionReader[ColumnarBatch] = {
     val combineConf = CombineConf(combineThresholdSize, combineWaitTime)
     new MultiFileCloudOrcPartitionReader(conf, files, dataSchema, readDataSchema, partitionSchema,
-      maxReadBatchSizeRows, maxReadBatchSizeBytes, numThreads, maxNumFileProcessed,
-      debugDumpPrefix, debugDumpAlways, filters, filterHandler, metrics, ignoreMissingFiles,
-      ignoreCorruptFiles, queryUsesInputFile, keepReadsInOrder, combineConf)
+      maxReadBatchSizeRows, maxReadBatchSizeBytes, targetBatchSizeBytes, numThreads,
+      maxNumFileProcessed, debugDumpPrefix, debugDumpAlways, filters, filterHandler, metrics,
+      ignoreMissingFiles, ignoreCorruptFiles, queryUsesInputFile, keepReadsInOrder, combineConf)
   }
 
   /**
@@ -604,8 +604,8 @@ case class GpuOrcMultiFilePartitionReaderFactory(
     }
     val clippedStripes = compressionAndStripes.values.flatten.toSeq
     new MultiFileOrcPartitionReader(conf, files, clippedStripes, readDataSchema,
-      debugDumpPrefix, debugDumpAlways, maxReadBatchSizeRows, maxReadBatchSizeBytes, metrics,
-      partitionSchema, numThreads, filterHandler.isCaseSensitive)
+      debugDumpPrefix, debugDumpAlways, maxReadBatchSizeRows, maxReadBatchSizeBytes,
+      targetBatchSizeBytes, metrics, partitionSchema, numThreads, filterHandler.isCaseSensitive)
   }
 
   /**
@@ -634,6 +634,7 @@ case class GpuOrcPartitionReaderFactory(
   private val debugDumpAlways = rapidsConf.orcDebugDumpAlways
   private val maxReadBatchSizeRows: Integer = rapidsConf.maxReadBatchSizeRows
   private val maxReadBatchSizeBytes: Long = rapidsConf.maxReadBatchSizeBytes
+  private val targetBatchSizeBytes: Long = rapidsConf.gpuTargetBatchSizeBytes
   private val filterHandler = GpuOrcFileFilterHandler(sqlConf, metrics, broadcastedConf,
     pushedFilters, rapidsConf.isOrcFloatTypesToStringEnable)
 
@@ -658,7 +659,8 @@ case class GpuOrcPartitionReaderFactory(
       val reader = new PartitionReaderWithBytesRead(new GpuOrcPartitionReader(conf, partFile, ctx,
         readDataSchema, debugDumpPrefix, debugDumpAlways,  maxReadBatchSizeRows,
         maxReadBatchSizeBytes, metrics, filterHandler.isCaseSensitive))
-      ColumnarPartitionReaderWithPartitionValues.newReader(partFile, reader, partitionSchema)
+      ColumnarPartitionReaderWithPartitionValues.newReader(partFile, reader, partitionSchema,
+        targetBatchSizeBytes)
     }
   }
 }
@@ -1949,6 +1951,7 @@ private object GpuOrcFileFilterHandler {
  * @param partitionSchema Schema of partitions.
  * @param maxReadBatchSizeRows soft limit on the maximum number of rows the reader reads per batch
  * @param maxReadBatchSizeBytes soft limit on the maximum number of bytes the reader reads per batch
+ * @param targetBatchSizeBytes target number of bytes for a GPU batch
  * @param numThreads the size of the threadpool
  * @param maxNumFileProcessed threshold to control the maximum file number to be
  *                            submitted to threadpool
@@ -1968,6 +1971,7 @@ class MultiFileCloudOrcPartitionReader(
     partitionSchema: StructType,
     maxReadBatchSizeRows: Integer,
     maxReadBatchSizeBytes: Long,
+    targetBatchSizeBytes: Long,
     numThreads: Int,
     maxNumFileProcessed: Int,
     override val debugDumpPrefix: Option[String],
@@ -2179,10 +2183,10 @@ class MultiFileCloudOrcPartitionReader(
           case Some(partRowsAndValues) =>
             val (rowsPerPart, partValues) = partRowsAndValues.unzip
             BatchWithPartitionDataUtils.addPartitionValuesToBatch(batch, rowsPerPart,
-              partValues, partitionSchema)
+              partValues, partitionSchema, targetBatchSizeBytes)
           case None =>
             BatchWithPartitionDataUtils.addSinglePartitionValueToBatch(batch,
-              meta.partitionedFile.partitionValues, partitionSchema)
+              meta.partitionedFile.partitionValues, partitionSchema, targetBatchSizeBytes)
         }
 
       case buffer: HostMemoryBuffersWithMetaData =>
@@ -2195,10 +2199,10 @@ class MultiFileCloudOrcPartitionReader(
               case Some(partRowsAndValues) =>
                 val (rowsPerPart, partValues) = partRowsAndValues.unzip
                 BatchWithPartitionDataUtils.addPartitionValuesToBatch(batch, rowsPerPart,
-                  partValues, partitionSchema)
+                  partValues, partitionSchema, targetBatchSizeBytes)
               case None =>
                 BatchWithPartitionDataUtils.addSinglePartitionValueToBatch(batch,
-                  buffer.partitionedFile.partitionValues, partitionSchema)
+                  buffer.partitionedFile.partitionValues, partitionSchema, targetBatchSizeBytes)
             }
           case _ =>
             EmptyGpuColumnarBatchIterator
@@ -2491,6 +2495,7 @@ private case class OrcSingleStripeMeta(
  * @param debugDumpAlways       whether to always debug dump or only on errors
  * @param maxReadBatchSizeRows  soft limit on the maximum number of rows the reader reads per batch
  * @param maxReadBatchSizeBytes soft limit on the maximum number of bytes the reader reads per batch
+ * @param targetBatchSizeBytes target number of bytes for a GPU batch
  * @param execMetrics           metrics
  * @param partitionSchema       schema of partitions
  * @param numThreads            the size of the threadpool
@@ -2505,12 +2510,14 @@ class MultiFileOrcPartitionReader(
     override val debugDumpAlways: Boolean,
     maxReadBatchSizeRows: Integer,
     maxReadBatchSizeBytes: Long,
+    targetBatchSizeBytes: Long,
     execMetrics: Map[String, GpuMetric],
     partitionSchema: StructType,
     numThreads: Int,
     isCaseSensitive: Boolean)
   extends MultiFileCoalescingPartitionReaderBase(conf, clippedStripes,
-    partitionSchema, maxReadBatchSizeRows, maxReadBatchSizeBytes, numThreads, execMetrics)
+    partitionSchema, maxReadBatchSizeRows, maxReadBatchSizeBytes, targetBatchSizeBytes,
+    numThreads, execMetrics)
     with OrcCommonFunctions {
 
   // implicit to convert SchemaBase to Orc TypeDescription

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -562,7 +562,7 @@ case class GpuOrcMultiFilePartitionReaderFactory(
       PartitionReader[ColumnarBatch] = {
     val combineConf = CombineConf(combineThresholdSize, combineWaitTime)
     new MultiFileCloudOrcPartitionReader(conf, files, dataSchema, readDataSchema, partitionSchema,
-      maxReadBatchSizeRows, maxReadBatchSizeBytes, targetBatchSizeBytes, numThreads,
+      maxReadBatchSizeRows, maxReadBatchSizeBytes, maxGpuColumnSizeBytes, numThreads,
       maxNumFileProcessed, debugDumpPrefix, debugDumpAlways, filters, filterHandler, metrics,
       ignoreMissingFiles, ignoreCorruptFiles, queryUsesInputFile, keepReadsInOrder, combineConf)
   }
@@ -605,7 +605,7 @@ case class GpuOrcMultiFilePartitionReaderFactory(
     val clippedStripes = compressionAndStripes.values.flatten.toSeq
     new MultiFileOrcPartitionReader(conf, files, clippedStripes, readDataSchema,
       debugDumpPrefix, debugDumpAlways, maxReadBatchSizeRows, maxReadBatchSizeBytes,
-      targetBatchSizeBytes, metrics, partitionSchema, numThreads, filterHandler.isCaseSensitive)
+      maxGpuColumnSizeBytes, metrics, partitionSchema, numThreads, filterHandler.isCaseSensitive)
   }
 
   /**
@@ -634,7 +634,7 @@ case class GpuOrcPartitionReaderFactory(
   private val debugDumpAlways = rapidsConf.orcDebugDumpAlways
   private val maxReadBatchSizeRows: Integer = rapidsConf.maxReadBatchSizeRows
   private val maxReadBatchSizeBytes: Long = rapidsConf.maxReadBatchSizeBytes
-  private val targetBatchSizeBytes: Long = rapidsConf.gpuTargetBatchSizeBytes
+  private val maxGpuColumnSizeBytes: Long = rapidsConf.maxGpuColumnSizeBytes
   private val filterHandler = GpuOrcFileFilterHandler(sqlConf, metrics, broadcastedConf,
     pushedFilters, rapidsConf.isOrcFloatTypesToStringEnable)
 
@@ -660,7 +660,7 @@ case class GpuOrcPartitionReaderFactory(
         readDataSchema, debugDumpPrefix, debugDumpAlways,  maxReadBatchSizeRows,
         maxReadBatchSizeBytes, metrics, filterHandler.isCaseSensitive))
       ColumnarPartitionReaderWithPartitionValues.newReader(partFile, reader, partitionSchema,
-        targetBatchSizeBytes)
+        maxGpuColumnSizeBytes)
     }
   }
 }
@@ -1951,7 +1951,7 @@ private object GpuOrcFileFilterHandler {
  * @param partitionSchema Schema of partitions.
  * @param maxReadBatchSizeRows soft limit on the maximum number of rows the reader reads per batch
  * @param maxReadBatchSizeBytes soft limit on the maximum number of bytes the reader reads per batch
- * @param targetBatchSizeBytes target number of bytes for a GPU batch
+ * @param maxGpuColumnSizeBytes maximum number of bytes for a GPU column
  * @param numThreads the size of the threadpool
  * @param maxNumFileProcessed threshold to control the maximum file number to be
  *                            submitted to threadpool
@@ -1971,7 +1971,7 @@ class MultiFileCloudOrcPartitionReader(
     partitionSchema: StructType,
     maxReadBatchSizeRows: Integer,
     maxReadBatchSizeBytes: Long,
-    targetBatchSizeBytes: Long,
+    maxGpuColumnSizeBytes: Long,
     numThreads: Int,
     maxNumFileProcessed: Int,
     override val debugDumpPrefix: Option[String],
@@ -2183,10 +2183,10 @@ class MultiFileCloudOrcPartitionReader(
           case Some(partRowsAndValues) =>
             val (rowsPerPart, partValues) = partRowsAndValues.unzip
             BatchWithPartitionDataUtils.addPartitionValuesToBatch(batch, rowsPerPart,
-              partValues, partitionSchema, targetBatchSizeBytes)
+              partValues, partitionSchema, maxGpuColumnSizeBytes)
           case None =>
             BatchWithPartitionDataUtils.addSinglePartitionValueToBatch(batch,
-              meta.partitionedFile.partitionValues, partitionSchema, targetBatchSizeBytes)
+              meta.partitionedFile.partitionValues, partitionSchema, maxGpuColumnSizeBytes)
         }
 
       case buffer: HostMemoryBuffersWithMetaData =>
@@ -2199,10 +2199,10 @@ class MultiFileCloudOrcPartitionReader(
               case Some(partRowsAndValues) =>
                 val (rowsPerPart, partValues) = partRowsAndValues.unzip
                 BatchWithPartitionDataUtils.addPartitionValuesToBatch(batch, rowsPerPart,
-                  partValues, partitionSchema, targetBatchSizeBytes)
+                  partValues, partitionSchema, maxGpuColumnSizeBytes)
               case None =>
                 BatchWithPartitionDataUtils.addSinglePartitionValueToBatch(batch,
-                  buffer.partitionedFile.partitionValues, partitionSchema, targetBatchSizeBytes)
+                  buffer.partitionedFile.partitionValues, partitionSchema, maxGpuColumnSizeBytes)
             }
           case _ =>
             EmptyGpuColumnarBatchIterator
@@ -2495,7 +2495,7 @@ private case class OrcSingleStripeMeta(
  * @param debugDumpAlways       whether to always debug dump or only on errors
  * @param maxReadBatchSizeRows  soft limit on the maximum number of rows the reader reads per batch
  * @param maxReadBatchSizeBytes soft limit on the maximum number of bytes the reader reads per batch
- * @param targetBatchSizeBytes target number of bytes for a GPU batch
+ * @param maxGpuColumnSizeBytes maxmium number of bytes for a GPU column
  * @param execMetrics           metrics
  * @param partitionSchema       schema of partitions
  * @param numThreads            the size of the threadpool
@@ -2510,13 +2510,13 @@ class MultiFileOrcPartitionReader(
     override val debugDumpAlways: Boolean,
     maxReadBatchSizeRows: Integer,
     maxReadBatchSizeBytes: Long,
-    targetBatchSizeBytes: Long,
+    maxGpuColumnSizeBytes: Long,
     execMetrics: Map[String, GpuMetric],
     partitionSchema: StructType,
     numThreads: Int,
     isCaseSensitive: Boolean)
   extends MultiFileCoalescingPartitionReaderBase(conf, clippedStripes,
-    partitionSchema, maxReadBatchSizeRows, maxReadBatchSizeBytes, targetBatchSizeBytes,
+    partitionSchema, maxReadBatchSizeRows, maxReadBatchSizeBytes, maxGpuColumnSizeBytes,
     numThreads, execMetrics)
     with OrcCommonFunctions {
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3657,7 +3657,8 @@ object GpuOverrides extends Logging {
             a.partitionFilters,
             a.dataFilters,
             conf.maxReadBatchSizeRows,
-            conf.maxReadBatchSizeBytes)
+            conf.maxReadBatchSizeBytes,
+            conf.gpuTargetBatchSizeBytes)
       }),
     GpuOverrides.scan[JsonScan](
       "Json parsing",
@@ -3674,7 +3675,8 @@ object GpuOverrides extends Logging {
             a.partitionFilters,
             a.dataFilters,
             conf.maxReadBatchSizeRows,
-            conf.maxReadBatchSizeBytes)
+            conf.maxReadBatchSizeBytes,
+            conf.gpuTargetBatchSizeBytes)
       })).map(r => (r.getClassFor.asSubclass(classOf[Scan]), r)).toMap
 
   val scans: Map[Class[_ <: Scan], ScanRule[_ <: Scan]] =

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3658,7 +3658,7 @@ object GpuOverrides extends Logging {
             a.dataFilters,
             conf.maxReadBatchSizeRows,
             conf.maxReadBatchSizeBytes,
-            conf.gpuTargetBatchSizeBytes)
+            conf.maxGpuColumnSizeBytes)
       }),
     GpuOverrides.scan[JsonScan](
       "Json parsing",
@@ -3676,7 +3676,7 @@ object GpuOverrides extends Logging {
             a.dataFilters,
             conf.maxReadBatchSizeRows,
             conf.maxReadBatchSizeBytes,
-            conf.gpuTargetBatchSizeBytes)
+            conf.maxGpuColumnSizeBytes)
       })).map(r => (r.getClassFor.asSubclass(classOf[Scan]), r)).toMap
 
   val scans: Map[Class[_ <: Scan], ScanRule[_ <: Scan]] =

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadCSVFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadCSVFileFormat.scala
@@ -65,7 +65,7 @@ class GpuReadCSVFileFormat extends CSVFileFormat with GpuReadFileFormatWithMetri
       csvOpts,
       rapidsConf.maxReadBatchSizeRows,
       rapidsConf.maxReadBatchSizeBytes,
-      rapidsConf.gpuTargetBatchSizeBytes,
+      rapidsConf.maxGpuColumnSizeBytes,
       metrics,
       options)
     PartitionReaderIterator.buildReader(factory)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadCSVFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadCSVFileFormat.scala
@@ -65,6 +65,7 @@ class GpuReadCSVFileFormat extends CSVFileFormat with GpuReadFileFormatWithMetri
       csvOpts,
       rapidsConf.maxReadBatchSizeRows,
       rapidsConf.maxReadBatchSizeBytes,
+      rapidsConf.gpuTargetBatchSizeBytes,
       metrics,
       options)
     PartitionReaderIterator.buildReader(factory)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -557,6 +557,16 @@ object RapidsConf {
       s"Batch size must be positive and not exceed ${Integer.MAX_VALUE} bytes.")
     .createWithDefault(1 * 1024 * 1024 * 1024) // 1 GiB is the default
 
+  val MAX_GPU_COLUMN_SIZE_BYTES = conf("spark.rapids.sql.columnSizeBytes")
+    .doc("Limit the max number of bytes for a GPU column. It is same as the cudf " +
+      "row count limit of a column. It is used by the multi-file readers. " +
+      "See com.nvidia.spark.rapids.BatchWithPartitionDataUtils.")
+    .internal()
+    .bytesConf(ByteUnit.BYTE)
+    .checkValue(v => v >= 0 && v <= Integer.MAX_VALUE,
+      s"Column size must be positive and not exceed ${Integer.MAX_VALUE} bytes.")
+    .createWithDefault(Integer.MAX_VALUE) // 2 GiB is the default
+
   val MAX_READER_BATCH_SIZE_ROWS = conf("spark.rapids.sql.reader.batchSizeRows")
     .doc("Soft limit on the maximum number of rows the reader will read per batch. " +
       "The orc and parquet readers will read row groups until this limit is met or exceeded. " +
@@ -2346,6 +2356,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val maxReadBatchSizeRows: Int = get(MAX_READER_BATCH_SIZE_ROWS)
 
   lazy val maxReadBatchSizeBytes: Long = get(MAX_READER_BATCH_SIZE_BYTES)
+
+  lazy val maxGpuColumnSizeBytes: Long = get(MAX_GPU_COLUMN_SIZE_BYTES)
 
   lazy val parquetDebugDumpPrefix: Option[String] = get(PARQUET_DEBUG_DUMP_PREFIX)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1829,12 +1829,6 @@ object RapidsConf {
     .booleanConf
     .createWithDefault(false)
 
-  val CUDF_COLUMN_SIZE_LIMIT = conf("spark.rapids.cudfColumnSizeLimit")
-    .internal()
-    .doc("Maximum size for cuDF column vector set to 2^31 - 1")
-    .longConf
-    .createWithDefault((1L << 31) - 1)
-
   val ALLOW_DISABLE_ENTIRE_PLAN = conf("spark.rapids.allowDisableEntirePlan")
     .internal()
     .doc("The plugin has the ability to detect possibe incompatibility with some specific " +
@@ -2621,8 +2615,6 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val shimsProviderOverride: Option[String] = get(SHIMS_PROVIDER_OVERRIDE)
 
   lazy val cudfVersionOverride: Boolean = get(CUDF_VERSION_OVERRIDE)
-
-  lazy val cudfColumnSizeLimit: Long = get(CUDF_COLUMN_SIZE_LIMIT)
 
   lazy val allowDisableEntirePlan: Boolean = get(ALLOW_DISABLE_ENTIRE_PLAN)
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
@@ -197,7 +197,8 @@ case class GpuJsonScan(
     partitionFilters: Seq[Expression],
     dataFilters: Seq[Expression],
     maxReaderBatchSizeRows: Integer,
-    maxReaderBatchSizeBytes: Long)
+    maxReaderBatchSizeBytes: Long,
+    targetSizeBytes: Long)
   extends TextBasedFileScan(sparkSession, options) with GpuScan {
 
   private lazy val parsedOptions: JSONOptions = new JSONOptions(
@@ -220,7 +221,7 @@ case class GpuJsonScan(
 
     GpuJsonPartitionReaderFactory(sparkSession.sessionState.conf, broadcastedConf,
       dataSchema, readDataSchema, readPartitionSchema, parsedOptions, maxReaderBatchSizeRows,
-      maxReaderBatchSizeBytes, metrics, options.asScala.toMap)
+      maxReaderBatchSizeBytes, targetSizeBytes, metrics, options.asScala.toMap)
   }
 
   override def withInputFile(): GpuScan = this
@@ -236,6 +237,7 @@ case class GpuJsonPartitionReaderFactory(
     parsedOptions: JSONOptions,
     maxReaderBatchSizeRows: Integer,
     maxReaderBatchSizeBytes: Long,
+    targetSizeBytes: Long,
     metrics: Map[String, GpuMetric],
     @transient params: Map[String, String]) extends ShimFilePartitionReaderFactory(params) {
 
@@ -248,7 +250,8 @@ case class GpuJsonPartitionReaderFactory(
     val reader = new PartitionReaderWithBytesRead(new JsonPartitionReader(conf, partFile,
       dataSchema, readDataSchema, parsedOptions, maxReaderBatchSizeRows, maxReaderBatchSizeBytes,
       metrics))
-    ColumnarPartitionReaderWithPartitionValues.newReader(partFile, reader, partitionSchema)
+    ColumnarPartitionReaderWithPartitionValues.newReader(partFile, reader, partitionSchema,
+      targetSizeBytes)
   }
 }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
@@ -198,7 +198,7 @@ case class GpuJsonScan(
     dataFilters: Seq[Expression],
     maxReaderBatchSizeRows: Integer,
     maxReaderBatchSizeBytes: Long,
-    targetSizeBytes: Long)
+    maxGpuColumnSizeBytes: Long)
   extends TextBasedFileScan(sparkSession, options) with GpuScan {
 
   private lazy val parsedOptions: JSONOptions = new JSONOptions(
@@ -221,7 +221,7 @@ case class GpuJsonScan(
 
     GpuJsonPartitionReaderFactory(sparkSession.sessionState.conf, broadcastedConf,
       dataSchema, readDataSchema, readPartitionSchema, parsedOptions, maxReaderBatchSizeRows,
-      maxReaderBatchSizeBytes, targetSizeBytes, metrics, options.asScala.toMap)
+      maxReaderBatchSizeBytes, maxGpuColumnSizeBytes, metrics, options.asScala.toMap)
   }
 
   override def withInputFile(): GpuScan = this
@@ -237,7 +237,7 @@ case class GpuJsonPartitionReaderFactory(
     parsedOptions: JSONOptions,
     maxReaderBatchSizeRows: Integer,
     maxReaderBatchSizeBytes: Long,
-    targetSizeBytes: Long,
+    maxGpuColumnSizeBytes: Long,
     metrics: Map[String, GpuMetric],
     @transient params: Map[String, String]) extends ShimFilePartitionReaderFactory(params) {
 
@@ -251,7 +251,7 @@ case class GpuJsonPartitionReaderFactory(
       dataSchema, readDataSchema, parsedOptions, maxReaderBatchSizeRows, maxReaderBatchSizeBytes,
       metrics))
     ColumnarPartitionReaderWithPartitionValues.newReader(partFile, reader, partitionSchema,
-      targetSizeBytes)
+      maxGpuColumnSizeBytes)
   }
 }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuReadJsonFileFormat.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuReadJsonFileFormat.scala
@@ -65,7 +65,7 @@ class GpuReadJsonFileFormat extends JsonFileFormat with GpuReadFileFormatWithMet
       jsonOpts,
       rapidsConf.maxReadBatchSizeRows,
       rapidsConf.maxReadBatchSizeBytes,
-      rapidsConf.gpuTargetBatchSizeBytes,
+      rapidsConf.maxGpuColumnSizeBytes,
       metrics,
       options)
     PartitionReaderIterator.buildReader(factory)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuReadJsonFileFormat.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuReadJsonFileFormat.scala
@@ -65,6 +65,7 @@ class GpuReadJsonFileFormat extends JsonFileFormat with GpuReadFileFormatWithMet
       jsonOpts,
       rapidsConf.maxReadBatchSizeRows,
       rapidsConf.maxReadBatchSizeBytes,
+      rapidsConf.gpuTargetBatchSizeBytes,
       metrics,
       options)
     PartitionReaderIterator.buildReader(factory)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
@@ -165,6 +165,7 @@ case class GpuAvroPartitionReaderFactory(
   private val debugDumpAlways = rapidsConf.avroDebugDumpAlways
   private val maxReadBatchSizeRows = rapidsConf.maxReadBatchSizeRows
   private val maxReadBatchSizeBytes = rapidsConf.maxReadBatchSizeBytes
+  private val targetSizeBytes = rapidsConf.gpuTargetBatchSizeBytes
 
   override def supportColumnarReads(partition: InputPartition): Boolean = true
 
@@ -182,7 +183,8 @@ case class GpuAvroPartitionReaderFactory(
     val reader = new PartitionReaderWithBytesRead(new GpuAvroPartitionReader(conf, partFile,
       blockMeta, readDataSchema, debugDumpPrefix, debugDumpAlways, maxReadBatchSizeRows,
       maxReadBatchSizeBytes, metrics))
-    ColumnarPartitionReaderWithPartitionValues.newReader(partFile, reader, partitionSchema)
+    ColumnarPartitionReaderWithPartitionValues.newReader(partFile, reader, partitionSchema,
+      targetSizeBytes)
   }
 }
 
@@ -240,7 +242,8 @@ case class GpuAvroMultiFilePartitionReaderFactory(
     }
     new GpuMultiFileCloudAvroPartitionReader(conf, files, numThreads, maxNumFileProcessed,
       filters, metrics, ignoreCorruptFiles, ignoreMissingFiles, debugDumpPrefix, debugDumpAlways,
-      readDataSchema, partitionSchema, maxReadBatchSizeRows, maxReadBatchSizeBytes)
+      readDataSchema, partitionSchema, maxReadBatchSizeRows, maxReadBatchSizeBytes,
+      targetBatchSizeBytes)
   }
 
   /**
@@ -293,8 +296,8 @@ case class GpuAvroMultiFilePartitionReaderFactory(
       _ += TimeUnit.NANOSECONDS.toMillis(filterTime)
     }
     new GpuMultiFileAvroPartitionReader(conf, files, clippedBlocks, readDataSchema,
-      partitionSchema, maxReadBatchSizeRows, maxReadBatchSizeBytes, numThreads,
-      debugDumpPrefix, debugDumpAlways, metrics, mapPathHeader.toMap)
+      partitionSchema, maxReadBatchSizeRows, maxReadBatchSizeBytes, targetBatchSizeBytes,
+      numThreads, debugDumpPrefix, debugDumpAlways, metrics, mapPathHeader.toMap)
   }
 
 }
@@ -630,6 +633,7 @@ class GpuAvroPartitionReader(
  * @param partitionSchema Schema of partitions.
  * @param maxReadBatchSizeRows soft limit on the maximum number of rows to be read per batch
  * @param maxReadBatchSizeBytes soft limit on the maximum number of bytes to be read per batch
+ * @param targetBatchSizeBytes target number of bytes for a GPU batch
  */
 class GpuMultiFileCloudAvroPartitionReader(
     override val conf: Configuration,
@@ -645,7 +649,8 @@ class GpuMultiFileCloudAvroPartitionReader(
     override val readDataSchema: StructType,
     partitionSchema: StructType,
     maxReadBatchSizeRows: Integer,
-    maxReadBatchSizeBytes: Long)
+    maxReadBatchSizeBytes: Long,
+    targetBatchSizeBytes: Long)
   extends MultiFileCloudPartitionReaderBase(conf, files, numThreads, maxNumFileProcessed, filters,
     execMetrics, maxReadBatchSizeRows, maxReadBatchSizeBytes,
     ignoreCorruptFiles) with MultiFileReaderFunctions with GpuAvroReaderBase {
@@ -662,14 +667,14 @@ class GpuMultiFileCloudAvroPartitionReader(
         GpuSemaphore.acquireIfNecessary(TaskContext.get())
         val emptyBatch = new ColumnarBatch(Array.empty, bufAndSizeInfo.numRows.toInt)
         BatchWithPartitionDataUtils.addSinglePartitionValueToBatch(emptyBatch,
-          partitionValues, partitionSchema)
+          partitionValues, partitionSchema, targetBatchSizeBytes)
       } else {
         val maybeBatch = sendToGpu(bufAndSizeInfo.hmb, bufAndSizeInfo.bytes, files)
         // we have to add partition values here for this batch, we already verified that
         // it's not different for all the blocks in this batch
         maybeBatch match {
           case Some(batch) => BatchWithPartitionDataUtils.addSinglePartitionValueToBatch(batch,
-            partitionValues, partitionSchema)
+            partitionValues, partitionSchema, targetBatchSizeBytes)
           case None => EmptyGpuColumnarBatchIterator
         }
       }
@@ -884,13 +889,14 @@ class GpuMultiFileAvroPartitionReader(
     partitionSchema: StructType,
     maxReadBatchSizeRows: Integer,
     maxReadBatchSizeBytes: Long,
+    targetBatchSizeBytes: Long,
     numThreads: Int,
     override val debugDumpPrefix: Option[String],
     override val debugDumpAlways: Boolean,
     execMetrics: Map[String, GpuMetric],
     mapPathHeader: Map[Path, Header])
   extends MultiFileCoalescingPartitionReaderBase(conf, clippedBlocks,
-    partitionSchema, maxReadBatchSizeRows, maxReadBatchSizeBytes, numThreads,
+    partitionSchema, maxReadBatchSizeRows, maxReadBatchSizeBytes, targetBatchSizeBytes, numThreads,
     execMetrics) with GpuAvroReaderBase {
 
   override def checkIfNeedToSplitDataBlock(

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/RapidsCsvScanMeta.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/RapidsCsvScanMeta.scala
@@ -63,5 +63,5 @@ class RapidsCsvScanMeta(
       cScan.dataFilters,
       conf.maxReadBatchSizeRows,
       conf.maxReadBatchSizeBytes,
-      conf.gpuTargetBatchSizeBytes)
+      conf.maxGpuColumnSizeBytes)
 }

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/RapidsCsvScanMeta.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/RapidsCsvScanMeta.scala
@@ -62,5 +62,6 @@ class RapidsCsvScanMeta(
       cScan.partitionFilters,
       cScan.dataFilters,
       conf.maxReadBatchSizeRows,
-      conf.maxReadBatchSizeBytes)
+      conf.maxReadBatchSizeBytes,
+      conf.gpuTargetBatchSizeBytes)
 }


### PR DESCRIPTION
This PR passes `maxGpuColumnSizeBytes` as a parameter from the caller to methods defined in `BatchWithPartitionDataUtils`. 

Note -  This PR adds a new config `spark.rapids.sql.columnSizeBytes`